### PR TITLE
Allow installation of league/html-to-markdown 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/phpunit-bridge": "^4.4.9|^5.0.9",
         "erusev/parsedown": "^1.7",
         "league/commonmark": "^1.0",
-        "league/html-to-markdown": "^4.8",
+        "league/html-to-markdown": "^4.8|^5.0",
         "michelf/php-markdown": "^1.8"
     },
     "autoload": {


### PR DESCRIPTION
Release notes: https://github.com/thephpleague/html-to-markdown/releases/tag/5.0.0

There were no changes that would impact how this Twig Markdown Extension calls the html-to-markdown library, meaning that both 4.8+ and 5.x should be fully compatible.