### PR TITLE
Fix for twigphp/Twig/issues/3685 (leading linebreaks and indentation)

### DIFF
--- a/MarkdownRuntime.php
+++ b/MarkdownRuntime.php
@@ -22,11 +22,37 @@ class MarkdownRuntime
 
     public function convert(string $body): string
     {
-        // remove indentation
-        if ($white = substr($body, 0, strspn($body, " \t\r\n\0\x0B"))) {
-            $body = preg_replace("{^$white}m", '', $body);
-        }
+        $body = $this->commonWhitespace($body);
+        $body = $this->removeIndentation($body);
 
         return $this->converter->convert($body);
+    }
+
+    protected function commonWhitespace(string $body): string
+    {
+        return str_replace(["\t", "\0", "\x0B"], ['    ', '', ''], $body);
+    }
+
+    protected function removeIndentation(string $body): string
+    {
+        $indent = $this->minIndentations($body);
+        if ($indent > 0) {
+            $body = preg_replace("{^ {{$indent}}}m", '', $body);
+        }
+
+        return $body;
+    }
+
+    protected function minIndentations(string $body): int
+    {
+        $non_empty_lines = preg_split('%(\r|\n)%', $body, -1, PREG_SPLIT_NO_EMPTY);
+
+        $list = [];
+        foreach ($non_empty_lines as $line)
+        {
+            $list[] = strspn($line, " ");
+        }
+
+        return min($list);
     }
 }


### PR DESCRIPTION
Reworked the "remove indentation" to properly account for all lines, work with leading linebreaks, and retain codeblocks at start of markdown.

Reworked the tests, to among other things compare with the markdown generated by the markdown library directly.