### PR TITLE
Use ConverterInterface type hint to allow other converter types

### DIFF
--- a/LeagueMarkdown.php
+++ b/LeagueMarkdown.php
@@ -12,13 +12,14 @@
 namespace Twig\Extra\Markdown;
 
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\ConverterInterface;
 
 class LeagueMarkdown implements MarkdownInterface
 {
     private $converter;
     private $legacySupport;
 
-    public function __construct(CommonMarkConverter $converter = null)
+    public function __construct(ConverterInterface $converter = null)
     {
         $this->converter = $converter ?: new CommonMarkConverter();
         $this->legacySupport = !method_exists($this->converter, 'convert');


### PR DESCRIPTION
This allows support for other commonmark converters such as the GithubFlavoredMarkdownConverter.