### PR TITLE
Accept null in markdown_to_html input

### DIFF
--- a/MarkdownRuntime.php
+++ b/MarkdownRuntime.php
@@ -20,8 +20,12 @@ class MarkdownRuntime
         $this->converter = $converter;
     }
 
-    public function convert(string $body): string
+    public function convert(?string $body): string
     {
+        if (empty($body)) {
+            return '';
+        }
+
         // remove indentation
         if ($white = substr($body, 0, strspn($body, " \t\r\n\0\x0B"))) {
             $body = preg_replace("{^$white}m", '', $body);

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -81,6 +81,7 @@ EOF
 EOF
             , "<h1>Hello</h1>\n+<p>Great!</p>"],
             ["{{ include('html')|markdown_to_html }}", "<h1>Hello</h1>\n+<p>Great!</p>"],
+            ['{{ null|markdown_to_html }}', ""]
         ];
     }
 }


### PR DESCRIPTION
This PR allows passing `null` value to the markdown converter, returning an empty string instead of throwing an error. 

Every significant Doctrine entity in my app has an optional Description field. I always push that value through the Markdown filter, and so I find myself always writing `{% if entity.description %}{{ entity.description|markdown_to_html }}{% endif %}`

The only reason for doing so is the fact `markdown_to_html` throws an error when receiving a null value. I think returning an empty value instead of a fatal error is a sane(r) default behaviour, hence this PR.

Thanks for reading.

