### PR TITLE
Allow usage of other Markdown converters than CommonMark in LeagueMarkdown

### DIFF
--- a/LeagueMarkdown.php
+++ b/LeagueMarkdown.php
@@ -12,13 +12,14 @@
 namespace Twig\Extra\Markdown;
 
 use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\MarkdownConverter;
 
 class LeagueMarkdown implements MarkdownInterface
 {
     private $converter;
     private $legacySupport;
 
-    public function __construct(?CommonMarkConverter $converter = null)
+    public function __construct(?MarkdownConverter $converter = null)
     {
         $this->converter = $converter ?: new CommonMarkConverter();
         $this->legacySupport = !method_exists($this->converter, 'convert');


### PR DESCRIPTION
Since the `CommonMarkConverter` from `League\CommonMark` doesn't allow customizing the `Environment` class at construct-time, this simple change allows providing an instance the parent class, so we can both inject a config to the converter AND a custom list of extensions (like `CommonMarkCoreExtension`) via the constructor.

